### PR TITLE
Added logic to handle %run magic as a code inclusion

### DIFF
--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -133,6 +133,7 @@ class NuclioExporter(Exporter):
                     lines = run_code['cells'][i]['source'].splitlines()
                     i += 1
                     self.handle_code_cell(lines, io, config)
+                continue
 
             self.handle_code_cell(lines, io, config)
 

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -15,7 +15,7 @@
 import json
 import logging
 import re
-from base64 import b64encode, b64decode
+from base64 import b64encode
 from collections import namedtuple
 from datetime import datetime
 from io import StringIO
@@ -327,19 +327,6 @@ def env_file(magic, config):
             continue
         env_files.add(file_name)
     return ''
-
-@magic_handler
-def run(magic, config):
-    # This functions assumes that the parameter to %run
-    # is a Jupyter Notebook
-    file_name = magic.args.strip()
-    code = ''
-    if not path.isfile(file_name):
-        log.warning('skipping %s - not found', file_name)
-
-    code = open(file_name,'r').read()
-
-    return code
 
 def process_env_files(env_files, config):
     # %nuclio env_file magic will populate this

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -129,7 +129,8 @@ class NuclioExporter(Exporter):
                 if not run_code:
                     continue
                 for i in range(len(run_code['cells'])):
-                    run_code['cells'][i]['source'] = '\n'.join(run_code['cells'][i]['source'])
+                    run_code['cells'][i]['source'] = '\n'.join(
+                        run_code['cells'][i]['source'])
                     lines = run_code['cells'][i]['source'].splitlines()
                     i += 1
                     self.handle_code_cell(lines, io, config)

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -32,7 +32,7 @@ from .utils import (env_keys, iter_env_lines, parse_config_line,
 from .archive import parse_archive_line
 from .config import (new_config, update_in, get_in, set_env, set_commands,
                      Volume, meta_keys)
-from .import magic as magic_module
+from . import magic as magic_module
 
 here = path.dirname(path.abspath(__file__))
 
@@ -127,7 +127,7 @@ class NuclioExporter(Exporter):
             if run_magic in code:
                 run_code = self.handle_run_magic(code)
                 if not run_code:
-                   continue
+                    continue
                 for i in range(len(run_code['cells'])):
                     run_code['cells'][i]['source'] = '\n'.join(run_code['cells'][i]['source'])
                     lines = run_code['cells'][i]['source'].splitlines()
@@ -180,23 +180,22 @@ class NuclioExporter(Exporter):
                 return i
         return -1
 
-
     def handle_run_magic(self, code):
-       # This functions assumes that the parameter to %run
-       # is a Jupyter Notebook
-       # Only one line %run per cell is supported
-       if '\n' in code:
-          log.error('Only one %run magic line per cell is supported')
-          raise MagicError('Only one %run magic line per cell is supported')
-          return ''
+        # This functions assumes that the parameter to %run
+        # is a Jupyter Notebook
+        # Only one line %run per cell is supported
+        if '\n' in code:
+            log.error('Only one %run magic line per cell is supported')
+            raise MagicError('Only one %run magic line per cell is supported')
+            return ''
 
-       magic, file_name = code.split()
-       code = ''
-       if not path.isfile(file_name):
-          log.warning('skipping %s - not found', file_name)
+        magic, file_name = code.split()
+        code = ''
+        if not path.isfile(file_name):
+            log.warning('skipping %s - not found', file_name)
 
-       code = json.loads(open(file_name,'r').read())
-       return code
+        code = json.loads(open(file_name, 'r').read())
+        return code
 
     def handle_cell_magic(self, lines, io, config):
         i = self.find_cell_magic(lines)
@@ -328,6 +327,7 @@ def env_file(magic, config):
         env_files.add(file_name)
     return ''
 
+
 def process_env_files(env_files, config):
     # %nuclio env_file magic will populate this
     from_env = json.loads(environ.get(env_keys.env_files, '[]'))
@@ -380,7 +380,7 @@ def handler_code(name, code):
             continue
 
         if 'return' not in line:
-            lines[len(lines)-i-1] = add_return(line)
+            lines[len(lines) - i - 1] = add_return(line)
         break
 
     return '\n'.join(lines)


### PR DESCRIPTION
**Current behavior**
The %run magic is ignored

**Coded behavior**
If the %run magic is inside the nuclio code block, read the cells in the external notebook and add them to the code. This change assumes all the cells in the external notebook will be added to the code at the same position where the %run magic's is. Only one %run per cell is accepted. An error will be raised if more than one is present or additional code is in the same cell.

**Why?**
We can move helper functions, common configuration steps and, in general,  code that is shared by multiple notebooks to an external notebook.
