### PR TITLE
Do not create project with displayName

### DIFF
--- a/nuclio/archive.py
+++ b/nuclio/archive.py
@@ -319,7 +319,7 @@ class GitRepo(ExternalRepo):
         self.headers = {'Authorization': ''}
         token = urlobj.username or environ.get('GIT_ACCESS_TOKEN')
         if token:
-            self.headers = {'Authorization': 'token '.format(token)}
+            self.headers = {'Authorization': 'token {0}'.format(token)}
 
         # format: git://[token@]github.com/org/repo#master[:<workdir>]
         self.branch = 'master'

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -330,10 +330,7 @@ def extend_config(config, spec, tag, source=''):
     if tag:
         config['metadata']['labels'][meta_keys.tag] = tag
     if source:
-        now = datetime.utcnow().strftime("%d-%m-%Y")
-        if environ.get('V3IO_USERNAME'):
-            now += ' by ' + environ.get('V3IO_USERNAME')
-        genstr = 'function generated from {0} to {1}'.format(now, source)
+        genstr = 'function generated from {0}'.format(source)
         config['metadata']['annotations'][meta_keys.generated_by] = genstr
 
     return config

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -333,7 +333,7 @@ def extend_config(config, spec, tag, source=''):
         now = datetime.utcnow().strftime("%d-%m-%Y")
         if environ.get('V3IO_USERNAME'):
             now += ' by ' + environ.get('V3IO_USERNAME')
-        genstr = 'function generated from {}'.format(now, source)
+        genstr = 'function generated from {0} to {1}'.format(now, source)
         config['metadata']['annotations'][meta_keys.generated_by] = genstr
 
     return config

--- a/nuclio/deploy.py
+++ b/nuclio/deploy.py
@@ -413,10 +413,15 @@ def find_or_create_project(api_url, project, create_new=False):
     if not resp.ok:
         raise OSError('nuclio API call failed')
     for k, v in resp.json().items():
-        if v['spec'].get('displayName') == project:
+        if v['metadata'].get('name') == project:
             return k
 
-        if k == project:
+        # displayName is deprecated
+        # older version of nuclio might still rely on it
+        elif v['spec'].get('displayName') == project:
+            return k
+
+        elif k == project:
             return k
 
     if not create_new:
@@ -424,7 +429,7 @@ def find_or_create_project(api_url, project, create_new=False):
 
     # create a new project
     headers = {'Content-Type': 'application/json'}
-    config = {"metadata": {"name": project}, "spec": {"displayName": project}}
+    config = {"metadata": {"name": project}, "spec": {}}
 
     try:
         resp = requests.post(apipath, json=config,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,7 +17,8 @@ def test_build_file_py():
     assert tag == 'v7', 'failed, tag not set properly config={}'.format(config)
 
     envs = config['spec']['env']
-    assert envs[0].get('name') == 'MYENV', 'build failed, env err'.format(envs)
+    assert_error_message = 'build failed, env err {0}'.format(envs)
+    assert envs[0].get('name') == 'MYENV', assert_error_message
 
 
 def test_build_file_nb():

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -37,12 +37,11 @@ functions = {
 }
 
 projects = {
-    '03ff81bf-00d6-41a4-899c-869a12f06d8c': {
+    "test-project": {
         "metadata": {
-            "name": "03ff81bf-00d6-41a4-899c-869a12f06d8c",
+            "name": "test-project",
             "namespace": "default-tenant"},
-        "spec":
-            {"displayName": "test-project"}
+        "spec": {},
     }
 }
 


### PR DESCRIPTION
Project `spec.displayName` field is deprecated, and soon would be blocked [see here](https://github.com/nuclio/nuclio/pull/1971)

+ few fixes