### PR TITLE
Support mlrun annotations in notebooks

### DIFF
--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -42,11 +42,11 @@ archive_settings = {}
 
 is_comment = re.compile(r'\s*#.*').match
 # # nuclio: return
-is_return = re.compile(r'#\s*nuclio:\s*return').search
+is_return = re.compile(r'#\s*(nuclio|mlrun):\s*return').search
 # # nuclio: ignore
-has_ignore = re.compile(r'#\s*nuclio:\s*ignore').search
-has_start = re.compile(r'#\s*nuclio:\s*start-code').search
-has_end = re.compile(r'#\s*nuclio:\s*end-code').search
+has_ignore = re.compile(r'#\s*(nuclio|mlrun):\s*ignore').search
+has_start = re.compile(r'#\s*(nuclio|mlrun):\s*start-code').search
+has_end = re.compile(r'#\s*(nuclio|mlrun):\s*end-code').search
 handler_decl = 'def {}(context, event):'
 indent_prefix = '    '
 line_magic = '%nuclio'

--- a/tests/annotations_test_cases.yml
+++ b/tests/annotations_test_cases.yml
@@ -1,0 +1,87 @@
+name: Only Ignore
+cells:
+  - |
+    # {keyword}: ignore
+    a = 1
+expected: |
+---
+name: Start and End with Ignore
+cells:
+  - |
+    # {keyword}: ignore
+    a = 1
+  - b = 2
+  - |
+    # {keyword}: start-code
+  - c = 3
+  - |
+    # {keyword}: end-code
+  - d = 4
+expected: c = 3
+---
+name: Start and End with Ignore in between
+cells:
+  - b = 2
+  - |
+    # {keyword}: start-code
+  - c = 3
+  - |
+    # {keyword}: ignore
+    a = 1
+  - |
+    # {keyword}: end-code
+  - d = 4
+expected: c = 3
+---
+name: Start and End
+cells:
+  - a = 1
+  - b = 2
+  - |
+    # {keyword}: start-code
+  - c = 3
+  - |
+    # {keyword}: end-code
+  - d = 4
+expected: c = 3
+---
+name: Only Start
+cells:
+  - a = 1
+  - b = 2
+  - |
+    # {keyword}: start-code
+  - c = 3
+  - d = 4
+expected: |
+  c = 3
+
+  d = 4
+---
+name: Only End
+cells:
+  - a = 1
+  - b = 2
+  - |
+    # {keyword}: end-code
+  - c = 3
+  - d = 4
+expected: |
+  a = 1
+
+  b = 2
+---
+name: No Keywords
+cells:
+  - a = 1
+  - b = 2
+  - c = 3
+  - d = 4
+expected: |
+  a = 1
+
+  b = 2
+
+  c = 3
+
+  d = 4

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -60,10 +60,10 @@ def test_export():
     assert 'def handler(' in code, 'no handler in code'
 
 
-def iter_convert():
-    with open('{}/convert_cases.yml'.format(here)) as fp:
-        for case in yaml.load_all(fp):
-            yield pytest.param(case, id=case['name'])
+def cases_from_yml_file(file_path: str):
+    with open(file_path) as f:
+        for case in yaml.load_all(f):
+            yield pytest.param(case, id=case["name"])
 
 
 def export_notebook(nb, resources=None):
@@ -74,12 +74,28 @@ def export_notebook(nb, resources=None):
     return code, config
 
 
-@pytest.mark.parametrize('case', iter_convert())
+@pytest.mark.parametrize('case', cases_from_yml_file(f"{here}/convert_cases.yml"))
 def test_convert(case, clean_handlers):
     nb = gen_nb([case['in']])
     code, _ = export_notebook(nb)
     code = code[code.find('\n'):].strip()  # Trim first line
     assert code == case['out'].strip()
+
+
+@pytest.mark.parametrize("case", cases_from_yml_file(f"{here}/annotations_test_cases.yml"))
+@pytest.mark.parametrize("keyword", ["mlrun", "nuclio"])
+def test_converter_annotations(case: dict, keyword: str):
+    notebook = {
+        "cells": [
+            {"source": code.format(keyword=keyword), "cell_type": "code"}
+            for code in case["cells"]
+        ],
+    }
+    code, _ = export_notebook(notebook)
+
+    # Trim first line
+    code = "\n".join(code.splitlines()[1:])
+    assert code.strip() == case["expected"].strip()
 
 
 def test_config():


### PR DESCRIPTION
- Notebook exporter supports `mlrun` code annotations
- Added tests for both `mlrun` and `nuclio` annotations.