### PR TITLE
Add host path volume mount option

### DIFF
--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -151,6 +151,11 @@ class Volume:
                 'name': self.name,
                 'persistentVolumeClaim': {'claimName': self.remote},
             }
+        elif self.type == 'host':
+            vol = {
+                'name': self.name,
+                'hostPath': {'path': self.remote},
+            }
         elif self.type == 'secret':
             vol = {
                 'name': self.name,


### PR DESCRIPTION
Right now the only way to do mounting is on v3io or with a pvc. This would allow people to do a simple host path mount. This is far easier when deploying nuclio locally and working interactively IMHO. I didn't see tests for this portion of the code, but I would be happy to add one for my addition if needed. The spec I'm using is here: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-configuration-example

It is also what nuclio UI generates:
![image](https://user-images.githubusercontent.com/70656471/112244781-5993ea80-8c15-11eb-961d-261615f8cc3b.png)
