### PR TITLE
Fix magic commands not being handled outside of start/end block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 README.html
 _t
 .idea
+venv

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -271,7 +271,7 @@ class NuclioExporter(Exporter):
                 continue
 
             if line_magic not in line:
-                # ignore command or magic commands (other than %nuclio)
+                # ignore commands (!) or any magic commands (other than %nuclio)
                 if not (line.startswith('!') or line.startswith('%')):
                     buf.append(line)
                 continue

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -255,7 +255,7 @@ class NuclioExporter(Exporter):
             if line_magic in line:
                 continue
 
-            # ignore commands (!) or any magic commands (other than %nuclio)
+            # ignore commands or any magic commands (other than %nuclio)
             if line.startswith('!') or line.startswith('%'):
                 continue
 
@@ -271,7 +271,7 @@ class NuclioExporter(Exporter):
                 continue
 
             if line_magic not in line:
-                # ignore commands (!) or any magic commands (other than %nuclio)
+                # ignore commands or any magic commands (other than %nuclio)
                 if not (line.startswith('!') or line.startswith('%')):
                     buf.append(line)
                 continue

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -158,28 +158,18 @@ class NuclioExporter(Exporter):
 
             lines = code.splitlines()
             if cell_magic in code:
-                self.handle_cell_magic(config,
-                                       lines,
-                                       function_buffers,
-                                       ended,
-                                       code_cells)
-                continue
+                code = self.handle_cell_magic(config, lines)
 
-            if line_magic in code:
-                self.handle_line_magic(config,
-                                       lines,
-                                       function_buffers,
-                                       ended,
-                                       code_cells)
-                continue
+            # must be else (cell_magic token contains line_magic)
+            elif line_magic in code:
+                code = self.handle_line_magic(config, lines)
 
             for function_buffer in function_buffers.values():
                 if not function_buffer[ended]:
                     function_buffer[code_cells].append(code)
 
         io = self.write_code_cells(
-            function_buffers[seen_function_name][code_cells],
-            config)
+            function_buffers[seen_function_name][code_cells])
         process_env_files(env_files, config)
         py_code = io.getvalue()
         handler_path = environ.get(env_keys.handler_path)
@@ -216,7 +206,7 @@ class NuclioExporter(Exporter):
 
         return config, resources
 
-    def write_code_cells(self, codes, config):
+    def write_code_cells(self, codes):
         io = StringIO()
         print(header(), file=io)
         for code in codes:
@@ -235,12 +225,7 @@ class NuclioExporter(Exporter):
                 return i
         return -1
 
-    def handle_cell_magic(self,
-                          config,
-                          lines,
-                          function_buffers,
-                          ended,
-                          code_cells):
+    def handle_cell_magic(self, config, lines):
         i = self.find_cell_magic(lines)
         if i == -1:
             raise MagicError('cannot find {}'.format(cell_magic))
@@ -259,10 +244,7 @@ class NuclioExporter(Exporter):
         else:
             code = handler(magic, config)
 
-        if code:
-            for function_buffer in function_buffers.values():
-                if not function_buffer[ended]:
-                    function_buffer[code_cells].append(code)
+        return code
 
     def handle_code_cell(self, lines, io):
         buf = []
@@ -270,25 +252,19 @@ class NuclioExporter(Exporter):
             if is_comment(line):
                 continue
 
-            if line_magic not in line:
-                # ignore command or magic commands (other than %nuclio)
-                if not (line.startswith('!') or line.startswith('%')):
-                    buf.append(line)
+            if line_magic in line:
                 continue
 
-            if buf:
-                print(ipython2python('\n'.join(buf)), file=io)
-                buf = []
+            # ignore commands (!) or any magic commands (other than %nuclio)
+            if line.startswith('!') or line.startswith('%'):
+                continue
+
+            buf.append(line)
 
         if buf:
             print(ipython2python('\n'.join(buf)), file=io)
 
-    def handle_line_magic(self,
-                          config,
-                          lines,
-                          function_buffers,
-                          ended,
-                          code_cells):
+    def handle_line_magic(self, config, lines):
         buf = []
         for line in lines:
             if is_comment(line):
@@ -299,13 +275,6 @@ class NuclioExporter(Exporter):
                 if not (line.startswith('!') or line.startswith('%')):
                     buf.append(line)
                 continue
-
-            if buf:
-                for function_buffer in function_buffers.values():
-                    if not function_buffer[ended]:
-                        function_buffer[code_cells].\
-                            append('\n'.join(buf))
-                buf = []
 
             name, args = parse_magic_line(line)
             magic = Magic(name, args, [], is_cell=False)
@@ -316,15 +285,9 @@ class NuclioExporter(Exporter):
 
             out = handler(magic, config)
             if out:
-                for function_buffer in function_buffers.values():
-                    if not function_buffer[ended]:
-                        function_buffer[code_cells].append(out)
+                buf.append(out)
 
-        if buf:
-            for function_buffer in function_buffers.values():
-                if not function_buffer[ended]:
-                    function_buffer[code_cells].\
-                        append('\n'.join(buf))
+        return '\n'.join(buf)
 
 
 def header():

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -158,11 +158,19 @@ class NuclioExporter(Exporter):
 
             lines = code.splitlines()
             if cell_magic in code:
-                self.handle_cell_magic(config, lines, function_buffers, ended, code_cells)
+                self.handle_cell_magic(config,
+                                       lines,
+                                       function_buffers,
+                                       ended,
+                                       code_cells)
                 continue
 
             if line_magic in code:
-                self.handle_line_magic(config, lines, function_buffers, ended, code_cells)
+                self.handle_line_magic(config,
+                                       lines,
+                                       function_buffers,
+                                       ended,
+                                       code_cells)
                 continue
 
             for function_buffer in function_buffers.values():
@@ -227,7 +235,12 @@ class NuclioExporter(Exporter):
                 return i
         return -1
 
-    def handle_cell_magic(self, config, lines, function_buffers, ended, code_cells):
+    def handle_cell_magic(self,
+                          config,
+                          lines,
+                          function_buffers,
+                          ended,
+                          code_cells):
         i = self.find_cell_magic(lines)
         if i == -1:
             raise MagicError('cannot find {}'.format(cell_magic))
@@ -270,7 +283,12 @@ class NuclioExporter(Exporter):
         if buf:
             print(ipython2python('\n'.join(buf)), file=io)
 
-    def handle_line_magic(self, config, lines, function_buffers, ended, code_cells):
+    def handle_line_magic(self,
+                          config,
+                          lines,
+                          function_buffers,
+                          ended,
+                          code_cells):
         buf = []
         for line in lines:
             if is_comment(line):
@@ -285,7 +303,8 @@ class NuclioExporter(Exporter):
             if buf:
                 for function_buffer in function_buffers.values():
                     if not function_buffer[ended]:
-                        function_buffer[code_cells].append(ipython2python('\n'.join(buf)))
+                        function_buffer[code_cells].\
+                            append(ipython2python('\n'.join(buf)))
                 buf = []
 
             name, args = parse_magic_line(line)
@@ -304,7 +323,8 @@ class NuclioExporter(Exporter):
         if buf:
             for function_buffer in function_buffers.values():
                 if not function_buffer[ended]:
-                    function_buffer[code_cells].append(ipython2python('\n'.join(buf)))
+                    function_buffer[code_cells].\
+                        append(ipython2python('\n'.join(buf)))
 
 
 def header():

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -262,7 +262,7 @@ class NuclioExporter(Exporter):
         if code:
             for function_buffer in function_buffers.values():
                 if not function_buffer[ended]:
-                    function_buffer[code_cells].append(ipython2python(code))
+                    function_buffer[code_cells].append(code)
 
     def handle_code_cell(self, lines, io):
         buf = []
@@ -304,7 +304,7 @@ class NuclioExporter(Exporter):
                 for function_buffer in function_buffers.values():
                     if not function_buffer[ended]:
                         function_buffer[code_cells].\
-                            append(ipython2python('\n'.join(buf)))
+                            append('\n'.join(buf))
                 buf = []
 
             name, args = parse_magic_line(line)
@@ -318,13 +318,13 @@ class NuclioExporter(Exporter):
             if out:
                 for function_buffer in function_buffers.values():
                     if not function_buffer[ended]:
-                        function_buffer[code_cells].append(ipython2python(out))
+                        function_buffer[code_cells].append(out)
 
         if buf:
             for function_buffer in function_buffers.values():
                 if not function_buffer[ended]:
                     function_buffer[code_cells].\
-                        append(ipython2python('\n'.join(buf)))
+                        append('\n'.join(buf))
 
 
 def header():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -443,6 +443,62 @@ def test_overlap_end_code():
     validate_code(cells[:4], cells[4:], cells)
 
 
+def test_handle_cell_magic_before_start():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '%nuclio cmd ls ${HOME}',
+        '# nuclio: start-code\nc=3',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_cell_magic_after_start():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '# nuclio: start-code\nc=3',
+        '%nuclio cmd ls ${HOME}',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_cell_magic_after_end():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '# nuclio: end-code\nc=3',
+        '%nuclio cmd ls ${HOME}',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_cell_magic_before_end():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '%nuclio cmd ls ${HOME}',
+        '# nuclio: end-code\nc=3',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
 def validate_code(expected_cells, expected_excluded_cells, cells):
     nb = gen_nb(cells)
     code, _ = export_notebook(nb)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -443,11 +443,82 @@ def test_overlap_end_code():
     validate_code(cells[:4], cells[4:], cells)
 
 
-def test_handle_cell_magic_before_start():
+def test_handle_line_magic_before_start():
     cells = [
         'a = 1',
         'b = 2',
         '%nuclio cmd ls ${HOME}',
+        '# nuclio: start-code\nc=3',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_line_magic_after_start():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '# nuclio: start-code\nc=3',
+        '%nuclio cmd ls ${HOME}',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_line_magic_after_end():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '# nuclio: end-code\nc=3',
+        '%nuclio cmd ls ${HOME}',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_line_magic_before_end():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '%nuclio cmd ls ${HOME}',
+        '# nuclio: end-code\nc=3',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_handle_line_magic_with_code():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '%nuclio cmd ls ${HOME}\nc=3',
+        '# nuclio: end-code',
+        'd = 4'
+    ]
+    nb = gen_nb(cells)
+    _, config = export_notebook(nb)
+    cmds = config['spec']['build']['commands']
+    assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+    validate_code(cells[:2]+['c=3'], cells[3:], cells)
+
+
+def test_handle_cell_magic_before_start():
+    cells = [
+        'a = 1',
+        'b = 2',
+        '%%nuclio cmd ls ${HOME}',
         '# nuclio: start-code\nc=3',
         'd = 4'
     ]
@@ -461,8 +532,8 @@ def test_handle_cell_magic_after_start():
     cells = [
         'a = 1',
         'b = 2',
-        '# nuclio: start-code\nc=3',
-        '%nuclio cmd ls ${HOME}',
+        '# nuclio: start-code',
+        '%%nuclio cmd ls ${HOME}',
         'd = 4'
     ]
     nb = gen_nb(cells)
@@ -475,8 +546,8 @@ def test_handle_cell_magic_after_end():
     cells = [
         'a = 1',
         'b = 2',
-        '# nuclio: end-code\nc=3',
-        '%nuclio cmd ls ${HOME}',
+        '# nuclio: end-code',
+        '%%nuclio cmd ls ${HOME}',
         'd = 4'
     ]
     nb = gen_nb(cells)
@@ -489,8 +560,8 @@ def test_handle_cell_magic_before_end():
     cells = [
         'a = 1',
         'b = 2',
-        '%nuclio cmd ls ${HOME}',
-        '# nuclio: end-code\nc=3',
+        '%%nuclio cmd ls ${HOME}',
+        '# nuclio: end-code',
         'd = 4'
     ]
     nb = gen_nb(cells)


### PR DESCRIPTION
Fix ignored magic commands outside of defined code blocks with `start-code` or `end-code` notations.
Now every magic command in the notebook should apply on all functions in that notebook.
Cells with magic commands will be applied once seen and code will be added to the function accordingly to the start\end code notations.