### PR TITLE
Add pytest fixtures to handle deletion of tests outputs

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,6 +1,30 @@
+import os
+import shutil
+
+import pytest
+
 from nuclio.build import build_file
 from nuclio.config import ConfigSpec, meta_keys, get_in
 from conftest import here
+
+
+@pytest.fixture()
+def url_filename():
+    url_filename = 'https://raw.githubusercontent.com/nuclio/nuclio/master/' \
+                   'hack/examples/java/empty/EmptyHandler.java'
+    yield url_filename
+    if os.path.exists('EmptyHandler.java'):
+        os.remove('EmptyHandler.java')
+    if os.path.exists('function.yaml'):
+        os.remove('function.yaml')
+
+
+@pytest.fixture()
+def project():
+    project = 'p1'
+    yield project
+    if os.path.exists(project):
+        shutil.rmtree(project)
 
 
 def test_build_file_py():
@@ -34,23 +58,22 @@ def test_build_file_nb():
     assert maxRep == 2, 'failed to set replicas, {}'.format(maxRep)
 
 
-def test_build_url():
-    filepath = 'https://raw.githubusercontent.com/nuclio/nuclio/master/hack/' \
-               + 'examples/java/empty/EmptyHandler.java'
-
-    name, config, code = build_file(filepath, name='javatst', output_dir='.')
+def test_build_url(url_filename):
+    name, config, code = build_file(url_filename,
+                                    name='javatst',
+                                    output_dir='.')
 
     assert name == 'javatst', 'build failed, name doesnt match={}'.format(name)
     assert config.get('spec'), 'build failed, config={}'.format(config)
     assert get_in(config, 'spec.runtime') == 'java', 'not java runtime'
 
 
-def test_build_file_zip():
+def test_build_file_zip(project):
     filepath = '{}/handler.py'.format(here)
     filepath = filepath.replace("\\", "/")  # handle windows
     spec = ConfigSpec(env={'MYENV': 'text'})
     name, config, code = build_file(filepath, name='hw', spec=spec,
-                                    archive=True, project='p1', tag='v7',
+                                    archive=True, project=project, tag='v7',
                                     output_dir='.')
 
     assert name == 'hw', 'build failed, name doesnt match={}'.format(name)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,10 +9,10 @@ from conftest import here
 
 
 @pytest.fixture()
-def url_filename():
-    url_filename = 'https://raw.githubusercontent.com/nuclio/nuclio/master/' \
+def url_filepath():
+    url_filepath = 'https://raw.githubusercontent.com/nuclio/nuclio/master/' \
                    'hack/examples/java/empty/EmptyHandler.java'
-    yield url_filename
+    yield url_filepath
     if os.path.exists('EmptyHandler.java'):
         os.remove('EmptyHandler.java')
     if os.path.exists('function.yaml'):
@@ -58,8 +58,8 @@ def test_build_file_nb():
     assert maxRep == 2, 'failed to set replicas, {}'.format(maxRep)
 
 
-def test_build_url(url_filename):
-    name, config, code = build_file(url_filename,
+def test_build_url(url_filepath):
+    name, config, code = build_file(url_filepath,
                                     name='javatst',
                                     output_dir='.')
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -66,6 +66,10 @@ def test_build_url(url_filepath):
     assert name == 'javatst', 'build failed, name doesnt match={}'.format(name)
     assert config.get('spec'), 'build failed, config={}'.format(config)
     assert get_in(config, 'spec.runtime') == 'java', 'not java runtime'
+    assert os.path.exists('EmptyHandler.java'), \
+        'EmptyHandler.java file was not created'
+    assert os.path.exists('function.yaml'), \
+        'function.yaml file was not created'
 
 
 def test_build_file_zip(project):
@@ -78,3 +82,6 @@ def test_build_file_zip(project):
 
     assert name == 'hw', 'build failed, name doesnt match={}'.format(name)
     assert config.get('spec'), 'build failed, config={}'.format(config)
+    assert os.path.exists(project), '{} dir was not created'.format(project)
+    zip_path = os.path.join(project, 'hw_v7.zip')
+    assert os.path.exists(zip_path), '{} dir was not created'.format(zip_path)


### PR DESCRIPTION
Added pytest fixtures to yield url_filename/project name and remove `test_build` outputs upon test completion (teardown).