### PR TITLE
Fix running notebook name resolution when it is a Jupyter server

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
-jupyter_server = "*"
+jupyter_server = "~=1.0"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
+jupyter_server = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -191,6 +191,6 @@ def notebook_file_name(ikernel):
             if session['kernel']['id'] == kernel_id:
                 relative_path = session['notebook']['path']
                 return path.join(
-                    srv['notebook_dir'] or srv['root_dir'],
+                    srv.get('notebook_dir') or srv.get('root_dir'),
                     relative_path
                 )

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -18,6 +18,7 @@ from os import path, environ
 import shlex
 from argparse import ArgumentParser
 from sys import stdout
+from itertools import chain
 
 import ipykernel
 from urllib.parse import urlencode, urljoin
@@ -183,7 +184,7 @@ def notebook_file_name(ikernel):
 
     kernel_id = re.search('kernel-(.*).json',
                           ipykernel.connect.get_connection_file()).group(1)
-    servers = nb_list_running_servers() + jp_list_running_servers()
+    servers = chain(nb_list_running_servers(), jp_list_running_servers())
     for srv in servers:
         query = {'token': srv.get('token', '')}
         url = urljoin(srv['url'], 'api/sessions') + '?' + urlencode(query)

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -184,6 +184,10 @@ def notebook_file_name(ikernel):
 
     kernel_id = re.search('kernel-(.*).json',
                           ipykernel.connect.get_connection_file()).group(1)
+
+    # list both notebook servers (nbserver-*.json) and the newer
+    # jupyter servers (jpserver-*.json), remove nb_list_running_servers()
+    # when fully moving to jupyter servers.
     servers = chain(nb_list_running_servers(), jp_list_running_servers())
     for srv in servers:
         query = {'token': srv.get('token', '')}
@@ -191,6 +195,8 @@ def notebook_file_name(ikernel):
         for session in json.load(urlopen(url)):
             if session['kernel']['id'] == kernel_id:
                 relative_path = session['notebook']['path']
+
+                # remove srv.get('notebook_dir') when fully moving to jupyter servers.
                 return path.join(
                     srv.get('notebook_dir') or srv.get('root_dir'),
                     relative_path

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -196,7 +196,8 @@ def notebook_file_name(ikernel):
             if session['kernel']['id'] == kernel_id:
                 relative_path = session['notebook']['path']
 
-                # remove srv.get('notebook_dir') when fully moving to jupyter servers.
+                # remove srv.get('notebook_dir') when fully moving to
+                # jupyter servers.
                 return path.join(
                     srv.get('notebook_dir') or srv.get('root_dir'),
                     relative_path


### PR DESCRIPTION
Migrate to jupyter_server - fix listing servers from both jupyter notebook and jupyter server with `nbserver` and `jpserver` respectively.
Our hacky code to resolve the running notebook name failed in the mlrun-kit jupyter, the reason was we used the new jupyter server introduced here: https://github.com/jupyter-server/jupyter_server .
the new server's metadata json is named `jpserver-{id}.json` while the old server's metadata is `nbserver-{id}.json`.
Hence, while listing the servers we couldn't find the correct server (and therefore the session) of the current notebook.
The solution was to chain the generators listing both types of servers and supporting both servers.