### PR TITLE
Move jupyter-server requirement to be a package extra 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,10 +13,6 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
-# <=1.0.8 cause above this version it requires a version of tornado that is incompatible with iguazio system that
-# is <3.2.0
-# TODO: When possible remove 1.0.8 limitation
-jupyter_server = "~=1.0, <=1.0.8"
 
 [dev-packages]
 flake8 = "*"

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -173,14 +173,14 @@ def notebook_file_name(ikernel):
         as nb_list_running_servers
     # installing jupyter-server is optional (only when doing pip install nuclio-jupyter[jupyter-server]) therefore don't
     # fail on import error
-    search_jupyter_server = False
+    jupyter_server_supported = False
     try:
         from jupyter_server.serverapp import list_running_servers \
             as jp_list_running_servers
     except ImportError:
         pass
     else:
-        search_jupyter_server = True
+        jupyter_server_supported = True
 
 
     file_name = environ.get('JUPYTER_NOTEBOOK_FILE_NAME')
@@ -198,7 +198,7 @@ def notebook_file_name(ikernel):
     # jupyter servers (jpserver-*.json), remove nb_list_running_servers()
     # when fully moving to jupyter servers.
     servers = nb_list_running_servers()
-    if search_jupyter_server:
+    if jupyter_server_supported:
         servers = chain(nb_list_running_servers(), jp_list_running_servers())
     for srv in servers:
         query = {'token': srv.get('token', '')}

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -171,8 +171,17 @@ def notebook_file_name(ikernel):
     # overcome it
     from notebook.notebookapp import list_running_servers \
         as nb_list_running_servers
-    from jupyter_server.serverapp import list_running_servers \
-        as jp_list_running_servers
+    # installing jupyter-server is optional (only when doing pip install nuclio-jupyter[jupyter-server]) therefore don't
+    # fail on import error
+    search_jupyter_server = False
+    try:
+        from jupyter_server.serverapp import list_running_servers \
+            as jp_list_running_servers
+    except ImportError:
+        pass
+    else:
+        search_jupyter_server = True
+
 
     file_name = environ.get('JUPYTER_NOTEBOOK_FILE_NAME')
     if file_name is not None:
@@ -188,7 +197,9 @@ def notebook_file_name(ikernel):
     # list both notebook servers (nbserver-*.json) and the newer
     # jupyter servers (jpserver-*.json), remove nb_list_running_servers()
     # when fully moving to jupyter servers.
-    servers = chain(nb_list_running_servers(), jp_list_running_servers())
+    servers = nb_list_running_servers()
+    if search_jupyter_server:
+        servers = chain(nb_list_running_servers(), jp_list_running_servers())
     for srv in servers:
         query = {'token': srv.get('token', '')}
         url = urljoin(srv['url'], 'api/sessions') + '?' + urlencode(query)

--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,8 @@ setup(
     tests_require=tests_require,
     extras_require={
         # jupyter-server is the new "infrastructure" of jupyter, in the Iguazio Jupyter we're still using an old version
-        # which uses the notebook-server. installing jupyter-server there is causing troubles (like unwanted-ly upgrading
-        # tornado, so we're installing jupyter-server only if explictly requested by adding an extra
+        # which uses the notebook-server. installing jupyter-server there is causing troubles (unwanted upgrade of
+        # tornado package, so we're installing jupyter-server only if explictly requested by adding an extra
         "jupyter-server": ["jupyter-server~=1.0"],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,12 @@ setup(
     ],
     setup_requires=['pytest-runner'],
     tests_require=tests_require,
+    extras_require={
+        # jupyter-server is the new "infrastructure" of jupyter, in the Iguazio Jupyter we're still using an old version
+        # which uses the notebook-server. installing jupyter-server there is causing troubles (like unwanted-ly upgrading
+        # tornado, so we're installing jupyter-server only if explictly requested by adding an extra
+        "jupyter-server": ["jupyter-server~=1.0"],
+    },
     entry_points={
         'nbconvert.exporters': [
             'nuclio=nuclio.export:NuclioExporter',


### PR DESCRIPTION
`jupyter-server` was added in https://github.com/nuclio/nuclio-jupyter/pull/110 to fix the current notebook name resolution logic to work in new Jupyter.
Installing it on the Iguazio Jupyter (which is the old notebook-server one) caused to un-wanted-ly upgrading tornado which causes problems, as a solution we tried (https://github.com/nuclio/nuclio-jupyter/pull/113) to limit jupyter-server to a version (<=1.0.8) that its tornado requirement is compatible with the Iguazio Jupyter's tornado version 
But this caused a crash in the mlrun-kit Jupyter which is running a much newer jupyter-server (1.6.4)
So the current suggested solution (done in this PR) is to remove jupyter-server from this package requirements, and adding it as an extra or the package, that way only if explicitly requested (by providing an extra) it will be installed 