### PR TITLE
Fix commented out magic parsing

### DIFF
--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -207,6 +207,7 @@ class NuclioExporter(Exporter):
                     function_buffers[current_name][ended] = True
                     seen_function_name = seen_function_name or current_name
 
+            code = filter_comments(code)
             lines = code.splitlines()
             if cell_magic in code:
                 code = self.handle_cell_magic(config, lines)
@@ -228,7 +229,6 @@ class NuclioExporter(Exporter):
         io = StringIO()
         print(header(), file=io)
         for code in codes:
-            code = filter_comments(code)
             if not code.strip():
                 continue
 

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -207,6 +207,7 @@ class NuclioExporter(Exporter):
                     function_buffers[current_name][ended] = True
                     seen_function_name = seen_function_name or current_name
 
+            # filter comments now to not erase start/end/ignore annotations but erase commented out magic
             code = filter_comments(code)
             lines = code.splitlines()
             if cell_magic in code:

--- a/tests/code_generation_test_cases.yml
+++ b/tests/code_generation_test_cases.yml
@@ -356,3 +356,14 @@ cells:
     c = 3
 expected: |
   b = 2
+---
+name: Commented cell magic after start code in cell
+function name: None
+cells:
+  - b = 2
+  - |
+    # nuclio: start-code
+    # %%nuclio cmd ls ${HOME}
+  - d = 4
+expected: |
+  d = 4

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -289,3 +289,20 @@ def test_converter_cell_and_line_magic(case: dict):
     _, config = export_notebook(notebook)
     cmds = config['spec']['build']['commands']
     assert environ['HOME'] in cmds[0], '${HOME} not expanded'
+
+
+def test_commented_out_line_magic():
+    cells = [
+        'd = 4\n'
+        '# %%nuclio cmd ls ${HOME}\n',
+        'a = 1',
+    ]
+    notebook = {
+        "cells": [
+            {"source": code, "cell_type": "code"}
+            for code in cells
+        ],
+    }
+    _, config = export_notebook(notebook)
+    cmds = config['spec']['build']['commands']
+    assert len(cmds) == 0, 'parsed commented out magic'


### PR DESCRIPTION
code_to_function fails with MagicError if notebook has a commented out magic, we now filter comments from code before parsing cell and line magic.
Bug happened during running mlrun demo realtime-face-recognition.