### PR TITLE
Scrubbing mktemp calls (CVE)

### DIFF
--- a/nuclio/deploy.py
+++ b/nuclio/deploy.py
@@ -14,9 +14,8 @@
 """Deploy notebook to nuclio"""
 import json
 import os
-from os import environ
+import tempfile
 from operator import itemgetter
-from tempfile import mktemp
 from time import sleep, time
 from datetime import datetime
 
@@ -64,20 +63,20 @@ def find_dashboard_url(dashboard_url=''):
 
     def with_prefix(url):
         api_prefix = '/api'
-        if environ.get('NUCLIO_DROP_API'):
+        if os.environ.get('NUCLIO_DROP_API'):
             api_prefix = ''
         return url + api_prefix
 
     if dashboard_url:
         return with_prefix(dashboard_url)
 
-    if 'NUCLIO_DASHBOARD_URL' in environ:
-        return with_prefix(environ.get('NUCLIO_DASHBOARD_URL'))
+    if 'NUCLIO_DASHBOARD_URL' in os.environ:
+        return with_prefix(os.environ.get('NUCLIO_DASHBOARD_URL'))
 
     for service, endpoint in service_names.items():
         env_name = service + '_SERVICE_PORT'
-        if env_name in environ:
-            port = environ.get(env_name) or '8070'
+        if env_name in os.environ:
+            port = os.environ.get(env_name) or '8070'
             return with_prefix('http://{}:{}'.format(endpoint, port))
 
     return with_prefix('http://localhost:8070')
@@ -230,7 +229,7 @@ def deploy_code(code, dashboard_url='', name='', project='', handler='',
     if files:
         zip_path = archive
         if url_target:
-            zip_path = mktemp('.zip')
+            zip_path = tempfile.NamedTemporaryFile(suffix='.zip', delete=False).name
         build_zip(zip_path, newconfig, code, files, lang)
         upload_file(zip_path, archive, True)
         newconfig = get_archive_config(name, archive)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -18,7 +18,7 @@ from glob import glob
 from os import environ
 from subprocess import run
 from sys import executable
-from tempfile import mkdtemp
+import tempfile
 
 import pytest
 import yaml
@@ -44,7 +44,7 @@ def temp_env(kw):
 
 
 def test_export():
-    out_dir = mkdtemp(prefix='nuclio-jupyter-export-')
+    out_dir = tempfile.mkdtemp(prefix='nuclio-jupyter-export-')
     cmd = [
         executable, '-m', 'nbconvert',
         '--to', 'nuclio.export.NuclioExporter',

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -17,7 +17,7 @@ from os import path
 from shutil import rmtree
 from subprocess import PIPE, run
 from sys import executable
-from tempfile import mkdtemp
+import tempfile
 
 from conftest import here, is_travis
 
@@ -36,7 +36,7 @@ def test_install():
     wheels = glob('{}/*.whl'.format(dist_dir))
     assert len(wheels) == 1, 'bad number of wheels'
 
-    venv_dir = mkdtemp(prefix='nuclio-jupyter-venv-')
+    venv_dir = tempfile.mkdtemp(prefix='nuclio-jupyter-venv-')
     print('venv = {}'.format(venv_dir))
     run(['virtualenv', '-p', executable, venv_dir], check=True)
 


### PR DESCRIPTION
`tempfile.mktemp()` manifests a known vulnerability wrt race condition between setting the path and obtaining the file handle, which is sometimes worrying, and pops up in security scans even when used in a safe context - https://cwe.mitre.org/data/definitions/377
It is hence deemed deprecated and vulnerable: https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables

The underlying issue here will still exist in some cases because the use case is valid - however, we will appease the scans