### PR TITLE
Keep comments on code extraction between start\end code annotations

### DIFF
--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -41,9 +41,7 @@ env_files = set()
 archive_settings = {}
 
 is_comment = re.compile(r'[ \t]*#.*').match
-is_annotation = re.compile(
-    r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*(return|ignore|start-code|end-code).*'
-).match
+is_annotation = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*(return|ignore|start-code|end-code).*').match
 # # nuclio: return
 is_return = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*return').search
 # # nuclio: ignore

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -40,18 +40,15 @@ magic_handlers = {}  # name -> function
 env_files = set()
 archive_settings = {}
 
+annotation_prefix = r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*'
 is_comment = re.compile(r'[ \t]*#.*').match
-is_annotation = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*(return|ignore|start-code|end-code).*').match
+is_annotation = re.compile(rf'{annotation_prefix}(return|ignore|start-code|end-code).*').match
 # # nuclio: return
-is_return = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*return').search
+is_return = re.compile(rf'{annotation_prefix}return').search
 # # nuclio: ignore
-has_ignore = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*ignore').search
-has_start = re.compile(
-    r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*start-code[ \t]*(?P<name>([\S]*))?'
-).search
-has_end = re.compile(
-    r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*end-code[ \t]*(?P<name>([\S]*))?'
-).search
+has_ignore = re.compile(rf'{annotation_prefix}ignore').search
+has_start = re.compile(rf'{annotation_prefix}start-code[ \t]*(?P<name>([\S]*))?').search
+has_end = re.compile(rf'{annotation_prefix}end-code[ \t]*(?P<name>([\S]*))?').search
 handler_decl = 'def {}(context, event):'
 indent_prefix = '    '
 line_magic = '%nuclio'

--- a/nuclio/export.py
+++ b/nuclio/export.py
@@ -41,6 +41,9 @@ env_files = set()
 archive_settings = {}
 
 is_comment = re.compile(r'[ \t]*#.*').match
+is_annotation = re.compile(
+    r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*(return|ignore|start-code|end-code).*'
+).match
 # # nuclio: return
 is_return = re.compile(r'[ \t]*#[ \t]*(nuclio|mlrun):[ \t]*return').search
 # # nuclio: ignore
@@ -207,8 +210,7 @@ class NuclioExporter(Exporter):
                     function_buffers[current_name][ended] = True
                     seen_function_name = seen_function_name or current_name
 
-            # filter comments now to not erase start/end/ignore annotations but erase commented out magic
-            code = filter_comments(code)
+            code = filter_annotations_and_commented_magic(code)
             lines = code.splitlines()
             if cell_magic in code:
                 code = self.handle_cell_magic(config, lines)
@@ -268,9 +270,6 @@ class NuclioExporter(Exporter):
     def handle_code_cell(self, lines, io):
         buf = []
         for line in lines:
-            if is_comment(line):
-                continue
-
             if line_magic in line:
                 continue
 
@@ -535,6 +534,8 @@ def handler_name():
     return '{}:{}'.format(module, name)
 
 
-def filter_comments(code):
-    lines = (line for line in code.splitlines() if not is_comment(line))
+def filter_annotations_and_commented_magic(code):
+    lines = [
+        line for line in code.splitlines() if not ((line_magic in line and is_comment(line)) or is_annotation(line))
+    ]
     return '\n'.join(lines)

--- a/tests/code_generation_test_cases.yml
+++ b/tests/code_generation_test_cases.yml
@@ -367,3 +367,16 @@ cells:
   - d = 4
 expected: |
   d = 4
+---
+name: User comment in code
+function name: None
+cells:
+  - b = 2
+  - |
+    # nuclio: start-code
+    # comment
+  - d = 4
+expected: |
+  # comment
+
+  d = 4


### PR DESCRIPTION
Instead of filtering all comments when extracting code from the notebook, only filter magic and code annotations.