### PR TITLE
Set env variables from k8s secrets in config spec

### DIFF
--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -213,17 +213,8 @@ def set_env_dict(config, env={}):
 
 
 def set_external_source_env_dict(config, external_source_env={}):
-    """expects env vars to be a dict or have attr to_dict()"""
     for k, v in external_source_env.items():
-        if isinstance(v, dict):
-            value_from = v
-        elif hasattr(v, 'to_dict'):
-            value_from = v.to_dict()
-        else:
-            raise Exception(f'external source env requires value_from to be either a dict '
-                            f'or an object with to_dict() attr, instead got: {v}')
-
-        update_env_var(config, k, value_from=value_from)
+        update_env_var(config, k, value_from=v)
 
 
 def update_env_var(config, key, value=None, value_from=None):
@@ -244,13 +235,15 @@ def update_env_var(config, key, value=None, value_from=None):
         config['spec']['env'].append(item)
 
 
-def fill_config(config, extra_config={}, env={}, cmd=[], mount: Volume = None):
+def fill_config(config, extra_config={}, env={}, cmd=[], mount: Volume = None, external_source_env={}):
     if config:
         for k, v in extra_config.items():
             current = get_in(config, k)
             update_in(config, k, v, isinstance(current, list))
     if env:
         set_env_dict(config, env)
+    if external_source_env:
+        set_external_source_env_dict(config, external_source_env)
     if cmd:
         set_commands(config, cmd)
     if mount:
@@ -261,9 +254,8 @@ class ConfigSpec:
     """Function configuration spec
 
     env                         - dictionary of environment variables {"key1": val1, ..}
-    external_source_env         - dictionary of names to value_from variables
+    external_source_env         - dictionary of names to "value_from" dictionary
                                 e.g. {"name1": {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}}, ..}
-                                value_from can be either a dict or an object with to_dict() attr.
     config                      - function spec parameters dictionary {"config_key": config, ..}
                                 e.g. {"config spec.build.baseImage" : "python:3.6-jessie"}
     cmd                         - string list with build commands

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -254,8 +254,8 @@ class ConfigSpec:
     """Function configuration spec
 
     env                         - dictionary of environment variables {"key1": val1, ..}
-    external_source_env         - dictionary of names to "value_from" dictionary
-                                e.g. {"name1": {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}}, ..}
+    external_source_env         - dictionary of names to "valueFrom" dictionary
+                                e.g. {"name1": {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}, ..}
     config                      - function spec parameters dictionary {"config_key": config, ..}
                                 e.g. {"config spec.build.baseImage" : "python:3.6-jessie"}
     cmd                         - string list with build commands

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -214,7 +214,7 @@ def set_env_dict(config, env={}):
 
 def set_secrets_dict(config, secrets={}):
     for k, v in secrets.items():
-        secret_key_ref = get_item_attr(v, 'secret_key_ref', {})
+        secret_key_ref = get_item_attr(v, 'secretKeyRef', {})
         name = get_item_attr(secret_key_ref, 'name', '')
         secret_key = get_item_attr(secret_key_ref, 'key', '')
         if not name or not secret_key:

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -223,8 +223,8 @@ def set_secrets_dict(config, secrets={}):
         secret_key_ref = v_dict.get('secret_key_ref', {})
         name = secret_key_ref.get('name', '')
         secret_key = secret_key_ref.get('key', '')
-        if not name:
-            logger.info(f'skipping nameless env variable from secret: {v}')
+        if not name or not secret_key:
+            logger.info(f'skipping nameless or keyless env variable from secret: {v}')
             continue
 
         value_from = {

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from base64 import b64decode
 from copy import deepcopy
 from os import path, environ
 import yaml
 from IPython import get_ipython
 
-from . import utils
-from .utils import parse_env, logger
+from .utils import parse_env, logger, get_item_attr
 from .archive import url2repo
 from .triggers import HttpTrigger
 
@@ -214,9 +214,9 @@ def set_env_dict(config, env={}):
 
 def set_secrets_dict(config, secrets={}):
     for k, v in secrets.items():
-        secret_key_ref = utils.get_item_attr(v, 'secret_key_ref', {})
-        name = utils.get_item_attr(secret_key_ref, 'name', '')
-        secret_key = utils.get_item_attr(secret_key_ref, 'key', '')
+        secret_key_ref = get_item_attr(v, 'secret_key_ref', {})
+        name = get_item_attr(secret_key_ref, 'name', '')
+        secret_key = get_item_attr(secret_key_ref, 'key', '')
         if not name or not secret_key:
             message = f'Env variable from secret must not be nameless nor keyless: {v}'
             logger.info(message)

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -220,7 +220,7 @@ def set_secrets_dict(config, secrets={}):
             logger.warning(f'failed to deserialize env variable from secret: {v}')
             raise e
 
-        secret_key_ref = v_dict.get('secret_key_ref', {})
+        secret_key_ref = v_dict.get('secretKeyRef', {}) or v_dict.get('secret_key_ref', {})
         name = secret_key_ref.get('name', '')
         secret_key = secret_key_ref.get('key', '')
         if not name or not secret_key:

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -212,3 +212,10 @@ def notebook_file_name(ikernel):
                     srv.get('notebook_dir') or srv.get('root_dir'),
                     relative_path
                 )
+
+
+def get_item_attr(item, attr, default=None):
+    if isinstance(item, dict):
+        return item.get(attr)
+    else:
+        return getattr(item, attr, default)

--- a/nuclio/utils.py
+++ b/nuclio/utils.py
@@ -212,10 +212,3 @@ def notebook_file_name(ikernel):
                     srv.get('notebook_dir') or srv.get('root_dir'),
                     relative_path
                 )
-
-
-def get_item_attr(item, attr, default=None):
-    if isinstance(item, dict):
-        return item.get(attr)
-    else:
-        return getattr(item, attr, default)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,31 +60,33 @@ def test_update_env_var_new_key():
         'env var was not added'
 
 
-def test_set_secrets_dict():
+def test_set_external_source_env_dict():
     config_dict = {'spec': {'env': []}}
     secrets = {
         'name1': {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}},
         'name2': {"secretKeyRef": {"name": "secret2", "key": "secret-key2"}},
+        'name3': {"configMapKeyRef": {"name": "config-map1", "key": "config-map-key1"}},
     }
-    config.set_secrets_dict(config_dict, secrets)
+    config.set_external_source_env_dict(config_dict, secrets)
 
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name1')['valueFrom'] == secrets['name1']
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name2')['valueFrom'] == secrets['name2']
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name3')['valueFrom'] == secrets['name3']
 
 
-def test_set_secrets_dict_missing_entries():
+def test_set_external_source_env_dict_missing_entries():
     config_dict = {'spec': {'env': []}}
     secrets = {
         'name1': {"secretKeyRef": {"key": "secret-key1"}},
         'name2': {"secretKeyRef": {"name": "secret2"}},
     }
     with pytest.raises(Exception) as exc:
-        config.set_secrets_dict(config_dict, secrets)
+        config.set_external_source_env_dict(config_dict, secrets)
         value_from = secrets['name1']
         assert str(exc) == f'Env variable from secret must not be nameless nor keyless: {value_from}'
 
     del secrets['name1']
     with pytest.raises(Exception) as exc:
-        config.set_secrets_dict(config_dict, secrets)
+        config.set_external_source_env_dict(config_dict, secrets)
         value_from = secrets['name2']
         assert str(exc) == f'Env variable from secret must not be nameless nor keyless: {value_from}'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,13 @@ def test_update_env_var_missing_value():
 
 
 def test_update_env_var_existing_key():
-    config_dict = {'spec': {'env': [{'name': 'key', 'value': 'value1'}, {'name': 'key2', 'value': 'value1'}]}}
+    config_dict = {'spec': {
+            'env': [
+                {'name': 'key', 'value': 'value1'},
+                {'name': 'key2', 'value': 'value1'},
+            ]
+        }
+    }
     config.update_env_var(config_dict, 'key', value='value2')
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
         'env var was not updated'
@@ -46,36 +52,31 @@ def test_update_env_var_new_key():
     config_dict = {'spec': {'env': []}}
     config.update_env_var(config_dict, 'key', value='value2')
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
-        'env var was not updated'
+        'env var was not added'
 
     value_from = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
     config.update_env_var(config_dict, 'key2', value_from=value_from)
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key2')['valueFrom'] == value_from,\
-        'env var was not updated'
+        'env var was not added'
 
 
 def test_set_secrets_dict():
     config_dict = {'spec': {'env': []}}
     secrets = {
-        'name1': {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}},
-        'name2': {"secret_key_ref": {"name": "secret2", "key": "secret-key2"}},
+        'name1': {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}},
+        'name2': {"secretKeyRef": {"name": "secret2", "key": "secret-key2"}},
     }
     config.set_secrets_dict(config_dict, secrets)
 
-    # verify changed to CamelCase
-    expected_value_from1 = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
-    expected_value_from2 = {"secretKeyRef": {"name": "secret2", "key": "secret-key2"}}
-    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name1')['valueFrom'] == expected_value_from1,\
-        'unexpected value from'
-    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name2')['valueFrom'] == expected_value_from2,\
-        'unexpected value from'
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name1')['valueFrom'] == secrets['name1']
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name2')['valueFrom'] == secrets['name2']
 
 
 def test_set_secrets_dict_missing_entries():
     config_dict = {'spec': {'env': []}}
     secrets = {
-        'name1': {"secret_key_ref": {"key": "secret-key1"}},
-        'name2': {"secret_key_ref": {"name": "secret2"}},
+        'name1': {"secretKeyRef": {"key": "secret-key1"}},
+        'name2': {"secretKeyRef": {"name": "secret2"}},
     }
     with pytest.raises(Exception) as exc:
         config.set_secrets_dict(config_dict, secrets)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 
 from nuclio import config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from nuclio import config
+
+
+def get_env_var_from_list_by_key(env, key):
+    for env_var in env:
+        if env_var['name'] == key:
+            return env_var
+    return None
+
+
+def test_update_env_var_missing_value():
+    config_dict = {'spec': {'env': []}}
+    with pytest.raises(Exception):
+        config.update_env_var(config_dict, 'name')
+
+
+def test_update_env_var_existing_key():
+    config_dict = {'spec': {'env': [{'name': 'key', 'value': 'value1'}, {'name': 'key2', 'value': 'value1'}]}}
+    config.update_env_var(config_dict, 'key', value='value2')
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
+        'env var was not updated'
+
+    value_from = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
+    config.update_env_var(config_dict, 'key2', value_from=value_from)
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key2')['valueFrom'] == value_from,\
+        'env var was not updated'
+
+
+def test_update_env_var_new_key():
+    config_dict = {'spec': {'env': []}}
+    config.update_env_var(config_dict, 'key', value='value2')
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
+        'env var was not updated'
+
+    value_from = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
+    config.update_env_var(config_dict, 'key2', value_from=value_from)
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key2')['valueFrom'] == value_from,\
+        'env var was not updated'
+
+
+def test_set_secrets_dict():
+    config_dict = {'spec': {'env': []}}
+    secrets = {
+        'name1': {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}},
+        'name2': {"secret_key_ref": {"name": "secret2", "key": "secret-key2"}},
+    }
+    config.set_secrets_dict(config_dict, secrets)
+
+    # verify changed to CamelCase
+    expected_value_from1 = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
+    expected_value_from2 = {"secretKeyRef": {"name": "secret2", "key": "secret-key2"}}
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name1')['valueFrom'] == expected_value_from1,\
+        'unexpected value from'
+    assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'name2')['valueFrom'] == expected_value_from2,\
+        'unexpected value from'
+
+
+def test_set_secrets_dict_missing_entries():
+    config_dict = {'spec': {'env': []}}
+    secrets = {
+        'name1': {"secret_key_ref": {"key": "secret-key1"}},
+        'name2': {"secret_key_ref": {"name": "secret2"}},
+    }
+    with pytest.raises(Exception) as exc:
+        config.set_secrets_dict(config_dict, secrets)
+        value_from = secrets['name1']
+        assert str(exc) == f'Env variable from secret must not be nameless nor keyless: {value_from}'
+
+    del secrets['name1']
+    with pytest.raises(Exception) as exc:
+        config.set_secrets_dict(config_dict, secrets)
+        value_from = secrets['name2']
+        assert str(exc) == f'Env variable from secret must not be nameless nor keyless: {value_from}'

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -145,6 +145,32 @@ def test_deploy_code(requests):
     assert func['status']['state'] == 'ready', 'not ready'
 
 
+def test_deploy_with_secret_env_vars(requests):
+    # define my function code template
+    code = '''
+    def handler(context, event):
+        context.logger.info('text')
+        return 'something'
+    '''
+
+    # deploy code with extra configuration (env vars, secrets)
+    secret = {"ENV1": {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}}}
+    expected_output_secret = {'name': 'ENV1', 'valueFrom': {'secretKeyRef': {'key': 'secret-key1', 'name': 'secret1'}}}
+    env_var = {'MYENV_VAR': 'something'}
+    expected_output_env_var = {'name': 'MYENV_VAR', 'value': 'something'}
+    spec = ConfigSpec(env=env_var, secrets=secret)
+    function_names = set(functions)
+    deploy.deploy_code(code, name='myfunc2', project='test-project',
+                       verbose=True, spec=spec)
+
+    new_function_names = set(functions)
+    assert len(new_function_names) == len(function_names) + 1, 'not deployed'
+    name = first(new_function_names - function_names)
+    func = functions[name]
+    assert expected_output_secret in func['spec']['env'], 'secret is not in function spec'
+    assert expected_output_env_var in func['spec']['env'], 'env var is not in function spec'
+
+
 class MockLogger:
     def __init__(self):
         self.logs = []

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -154,8 +154,9 @@ def test_deploy_with_secret_env_vars(requests):
     '''
 
     # deploy code with extra configuration (env vars, secrets)
-    secret = {"ENV1": {"secret_key_ref": {"name": "secret1", "key": "secret-key1"}}}
-    expected_output_secret = {'name': 'ENV1', 'valueFrom': {'secretKeyRef': {'key': 'secret-key1', 'name': 'secret1'}}}
+    name = 'ENV1'
+    secret = {name: {'secretKeyRef': {'name': 'secret1', 'key': 'secret-key1'}}}
+    expected_output_secret = {'name': name, 'valueFrom': secret[name]}
     env_var = {'MYENV_VAR': 'something'}
     expected_output_env_var = {'name': 'MYENV_VAR', 'value': 'something'}
     spec = ConfigSpec(env=env_var, secrets=secret)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -145,7 +145,7 @@ def test_deploy_code(requests):
     assert func['status']['state'] == 'ready', 'not ready'
 
 
-def test_deploy_with_secret_env_vars(requests):
+def test_deploy_with_external_source_env(requests):
     # define my function code template
     code = '''
     def handler(context, event):
@@ -153,13 +153,13 @@ def test_deploy_with_secret_env_vars(requests):
         return 'something'
     '''
 
-    # deploy code with extra configuration (env vars, secrets)
+    # deploy code with extra configuration (env vars, external_source_env)
     name = 'ENV1'
-    secret = {name: {'secretKeyRef': {'name': 'secret1', 'key': 'secret-key1'}}}
-    expected_output_secret = {'name': name, 'valueFrom': secret[name]}
+    external_source_env = {name: {'secretKeyRef': {'name': 'secret1', 'key': 'secret-key1'}}}
+    expected_output_env = {'name': name, 'valueFrom': external_source_env[name]}
     env_var = {'MYENV_VAR': 'something'}
     expected_output_env_var = {'name': 'MYENV_VAR', 'value': 'something'}
-    spec = ConfigSpec(env=env_var, secrets=secret)
+    spec = ConfigSpec(env=env_var, external_source_env=external_source_env)
     function_names = set(functions)
     deploy.deploy_code(code, name='myfunc2', project='test-project',
                        verbose=True, spec=spec)
@@ -168,7 +168,7 @@ def test_deploy_with_secret_env_vars(requests):
     assert len(new_function_names) == len(function_names) + 1, 'not deployed'
     name = first(new_function_names - function_names)
     func = functions[name]
-    assert expected_output_secret in func['spec']['env'], 'secret is not in function spec'
+    assert expected_output_env in func['spec']['env'], 'secret is not in function spec'
     assert expected_output_env_var in func['spec']['env'], 'env var is not in function spec'
 
 


### PR DESCRIPTION
Enable adding to nuclio function spec env variables that originate from a k8s secret and key, e.g. `{"name": "ENV1", "valueFrom": {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}}`.
We will receive a dict of external source env i.e. `name` to `valueFrom` mapping, and add it to the config on `merge`.