### PR TITLE
Change nuclio default runtime version

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
           python -m pipenv install --dev
 
       - id: cache-pipenv
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
@@ -56,7 +56,7 @@ jobs:
           python -m pipenv install --dev
 
       - id: cache-pipenv
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ we can use local environment variables in those commands with `${VAR_NAME}`, see
 ```
 %nuclio cmd pip install textblob
 %nuclio env TO_LANG=fr
-%nuclio config spec.build.baseImage = "python:3.6-jessie"
+%nuclio config spec.build.baseImage = "python:3.7-buster"
 ```
 
 magic commands only accept constant values or local environment variables as parameters 
@@ -205,7 +205,7 @@ metadata:
   name: nuclio-example
 spec:
   build:
-    baseImage: python:3.6-jessie
+    baseImage: python:3.7-buster
     commands:
     - pip install textblob
     noBaseImagesPull: true
@@ -213,12 +213,12 @@ spec:
   - name: TO_LANG
     value: fr
   handler: handler:handler
-  runtime: python:3.6
+  runtime: python
 ```
 
 ## Exporting functions using Jupyter UI
 in many cases we just want to export the function into a YAML/Zip file and loaded manually to nuclio (e.g. via nuclio UI).
-this package automatically register it self as a Jupyter converter, which allow exporting a notebook into nuclio format,
+this package automatically register itself as a Jupyter converter, which allow exporting a notebook into nuclio format,
 see example below, choose `File/Download as/Nuclio` in Jupyter notebook 
 > Note: you might need to mark the notebook as `Trusted` in order for the Nuclio option to show
 
@@ -289,7 +289,7 @@ methods can be nested, example:
 ```python
 # nuclio: ignore
 spec = nuclio.ConfigSpec(cmd=build_commands)\
-    .set_config('build.baseImage', 'python:3.6-jessie')\
+    .set_config('build.baseImage', 'python:3.7-buster')\
     .add_volume(local='User', remote='~/')
 
 spec.with_v3io()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,7 @@ And ``function.yaml``
    kind: Function
    metadata: {}
    spec:
-     runtime: python:3.6
+     runtime: python
      handler: handler:handler
      env:
        - name: API_KEY

--- a/docs/nlp-example.ipynb
+++ b/docs/nlp-example.ipynb
@@ -1,10 +1,12 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# nuclio: ignore\n",
     "# if the nuclio-jupyter package is not installed run !pip install nuclio-jupyter\n",
@@ -12,27 +14,16 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: textblob in ./.pythonlibs/lib/python3.6/site-packages (0.15.3)\n",
-      "Requirement already satisfied: nltk>=3.1 in ./.pythonlibs/lib/python3.6/site-packages (from textblob) (3.4)\n",
-      "Requirement already satisfied: six in /conda/lib/python3.6/site-packages (from nltk>=3.1->textblob) (1.12.0)\n",
-      "Requirement already satisfied: singledispatch in ./.pythonlibs/lib/python3.6/site-packages (from nltk>=3.1->textblob) (3.4.0.3)\n",
-      "%nuclio: setting 'TO_LANG' environment variable\n",
-      "%nuclio: setting spec.build.baseImage to 'python:3.6-jessie'\n"
-     ]
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
     }
-   ],
+   },
    "source": [
     "%nuclio cmd pip install textblob\n",
     "%nuclio env TO_LANG=fr\n",
-    "%nuclio config spec.build.baseImage = \"python:3.6-jessie\""
+    "%nuclio config spec.build.baseImage = \"python:3.7-buster\""
    ]
   },
   {

--- a/docs/nuclio-example.ipynb
+++ b/docs/nuclio-example.ipynb
@@ -1,10 +1,12 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# nuclio: ignore\n",
     "# if the nuclio-jupyter package is not installed run !pip install nuclio-jupyter\n",
@@ -57,12 +59,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "%nuclio: setting spec.build.baseImage to 'python:3.6-jessie'\n"
+      "%nuclio: setting spec.build.baseImage to 'python:3.7-buster'\n"
      ]
     }
    ],
    "source": [
-    "%nuclio config spec.build.baseImage = \"python:3.6-jessie\""
+    "%nuclio config spec.build.baseImage = \"python:3.7-buster\""
    ]
   },
   {
@@ -143,7 +145,11 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -160,9 +166,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -43,7 +43,7 @@ _function_config = {
         'annotations': {},
     },
     'spec': {
-        'runtime': 'python:3.6',
+        'runtime': 'python',
         'handler': None,
         'env': [],
         'volumes': [],
@@ -255,7 +255,7 @@ class ConfigSpec:
     external_source_env         - dictionary of names to "valueFrom" dictionary
                                 e.g. {"name1": {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}, ..}
     config                      - function spec parameters dictionary {"config_key": config, ..}
-                                e.g. {"config spec.build.baseImage" : "python:3.6-jessie"}
+                                e.g. {"config spec.build.baseImage" : "python:3.7"}
     cmd                         - string list with build commands
                                 e.g. ["pip install requests", "apt-get wget -y"]
     mount                       - Volume object for remote mount into a function

--- a/tests/deploy.json
+++ b/tests/deploy.json
@@ -9,7 +9,7 @@
   "spec": {
     "description": "Showcases unstructured logging and a structured response.",
     "handler": "main:handler",
-    "runtime": "python:3.6",
+    "runtime": "python",
     "resources": {},
     "image": "docker-registry.iguazio.app.ygmcdllkcwae.dev.trl.iguazio.com:80/nuclio/processor-helw:latest",
     "imageHash": "1546546171683541925",
@@ -106,7 +106,7 @@
               "platform": {},
               "resources": {},
               "runRegistry": "docker-registry.iguazio.app.ygmcdllkcwae.dev.trl.iguazio.com:80",
-              "runtime": "python:3.6",
+              "runtime": "python",
               "version": -1
             }
           }


### PR DESCRIPTION
Instead of explicitly use python:3.6 version, default to `python` which is determined by nuclio's BE