### PR TITLE
[Requirements] Pin jinja2 version to ~=3.0.0 and add upper bound to pyyaml <6.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ ipython = ">=5.5"
 #jupyterlab = ">=0.35.4"
 nbconvert = ">=5.4"
 notebook = ">=5.2.0"
-pyyaml = ">=3.13"
+pyyaml = ">=3.13, <=5.4.1"
 requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ requests = ">=2.20.1"
 #tornado = ">=5"
 boto3 = ">=1.9"
 # TODO remove this requirement once jupyter/nbconvert solves the issue
-jinja = "~=3.0.0"
+jinja2 = "~=3.0.0"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
+jinja = "~=3.0.0"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
-# TODO remove this requirement once jupyter/nbconvert solves the issue
+# TODO remove this requirement once jupyter/nbconvert solves the issue https://github.com/jupyter/nbconvert/issues/1736
 jinja2 = "~=3.0.0"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,8 @@ ipython = ">=5.5"
 #jupyterlab = ">=0.35.4"
 nbconvert = ">=5.4"
 notebook = ">=5.2.0"
-pyyaml = ">=3.13, <=5.4.1"
+# pyyaml 6.0 added backwards incompatible change https://github.com/yaml/pyyaml/issues/576
+pyyaml = ">=3.13, <6.0.0"
 requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
+# TODO remove this requirement once jupyter/nbconvert solves the issue
 jinja = "~=3.0.0"
 
 [dev-packages]


### PR DESCRIPTION
 https://github.com/jupyter/nbconvert/issues/1736
 
jinja2 3.1.0 deprecated jinja2.utils.escape which is being used by nbconvert.
pinning jinja2 version to ~=3.0.0 fixes the issue for now.

Added todo to remove the requirement once jupyter/nbconvert which are using the package resolve the issue
