### PR TITLE
KafkaTrigger - Switch attribute names to camelCase

### DIFF
--- a/nuclio/triggers.py
+++ b/nuclio/triggers.py
@@ -148,14 +148,14 @@ class KafkaTrigger(NuclioTrigger):
                 "kind": self.kind,
                 "maxWorkers": 1,
                 "attributes": {
-                    "Topics": topics,
-                    "Brokers": brokers,
-                    "ConsumerGroup": consumer_group,
-                    "InitialOffset": initial_offset,
-                    "SessionTimeout": "10s",
-                    "HeartbeatInterval": "3s",
-                    "WorkerAllocationMode": "pool",
-                    "FetchDefault": 1048576,
+                    "topics": topics,
+                    "brokers": brokers,
+                    "consumerGroup": consumer_group,
+                    "initialOffset": initial_offset,
+                    "sessionTimeout": "10s",
+                    "heartbeatInterval": "3s",
+                    "workerAllocationMode": "pool",
+                    "fetchDefault": 1048576,
                 },
             }
         )


### PR DESCRIPTION
Kafka trigger attributes are camelCase-d.
Since the attributes are not a part of the schema, there is no validations on them.
Capitalized attributes are not read properly by neither Nuclio nor the UI.