### PR TITLE
[Requirements] Unpin jinja2 and bump nbconvert to 6.4.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 ipython = ">=5.5"
 #jupyterlab = ">=0.35.4"
-nbconvert = ">=5.4"
+nbconvert = ">=6.4.5"
 notebook = ">=5.2.0"
 # pyyaml 6.0 added backwards incompatible change https://github.com/yaml/pyyaml/issues/576
 pyyaml = ">=3.13, <6.0.0"

--- a/Pipfile
+++ b/Pipfile
@@ -14,8 +14,6 @@ requests = ">=2.20.1"
 # nbconvert is not compatible with tornado 6 (which is in alpha)
 #tornado = ">=5"
 boto3 = ">=1.9"
-# TODO remove this requirement once jupyter/nbconvert solves the issue https://github.com/jupyter/nbconvert/issues/1736
-jinja2 = "~=3.0.0"
 
 [dev-packages]
 flake8 = "*"


### PR DESCRIPTION
As https://github.com/jupyter/nbconvert/issues/1736 was resolved and the fix https://github.com/jupyter/nbconvert/pull/1737 is available from nbconvert release 6.4.5.