### PR TITLE
Config - safely load env from config.spec

### DIFF
--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -18,7 +18,7 @@ from os import path, environ
 import yaml
 from IPython import get_ipython
 
-from .utils import parse_env
+from .utils import parse_env, logger
 from .archive import url2repo
 from .triggers import HttpTrigger
 
@@ -240,7 +240,10 @@ def create_or_update_env_var(config, key, value=None, value_from=None):
 
 
 def update_env_var(config, key, value=None, value_from=None):
-    # This function is deprecated, use create_or_update_env_var instead
+    logger.warning(
+        "update_env_var is deprecated, use create_or_update_env_var instead"
+        "This will be deprecated in 0.9.4, and will be removed in 1.0.0",
+    )
     create_or_update_env_var(config, key, value=value, value_from=value_from)
 
 

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -217,7 +217,7 @@ def set_external_source_env_dict(config, external_source_env={}):
         update_env_var(config, k, value_from=v)
 
 
-def update_env_var(config, key, value=None, value_from=None):
+def create_or_update_env_var(config, key, value=None, value_from=None):
     if value is not None:
         item = {'name': key, 'value': value}
     elif value_from is not None:
@@ -225,12 +225,23 @@ def update_env_var(config, key, value=None, value_from=None):
     else:
         raise Exception(f'either value or value_from required for env var: {key}')
 
+    config["spec"].setdefault("env", [])
+
     # find key existence in env
-    location = next((idx for idx, env_var in enumerate(config['spec']['env']) if env_var['name'] == key), None)
+    try:
+        location = [env["name"] for env in config["spec"]["env"]].index(key)
+    except ValueError:
+        location = None
+
     if location is not None:
         config['spec']['env'][location] = item
     else:
         config['spec']['env'].append(item)
+
+
+def update_env_var(config, key, value=None, value_from=None):
+    logger.warning('This function is deprecated, please use create_or_update_env_var instead')
+    create_or_update_env_var(config, key, value=value, value_from=value_from)
 
 
 def fill_config(config, extra_config={}, env={}, cmd=[], mount: Volume = None, external_source_env={}):

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -18,7 +18,7 @@ from os import path, environ
 import yaml
 from IPython import get_ipython
 
-from .utils import parse_env
+from .utils import parse_env, logger
 from .archive import url2repo
 from .triggers import HttpTrigger
 

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -18,7 +18,7 @@ from os import path, environ
 import yaml
 from IPython import get_ipython
 
-from .utils import parse_env, logger
+from .utils import parse_env
 from .archive import url2repo
 from .triggers import HttpTrigger
 

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -225,11 +225,12 @@ def create_or_update_env_var(config, key, value=None, value_from=None):
     else:
         raise Exception(f'either value or value_from required for env var: {key}')
 
-    config["spec"].setdefault("env", [])
+    config['spec'].setdefault('env', [])
 
     # find key existence in env
+    env_names = [env['name'] for env in config['spec']['env']]
     try:
-        location = [env["name"] for env in config["spec"]["env"]].index(key)
+        location = env_names.index(key)
     except ValueError:
         location = None
 
@@ -241,8 +242,8 @@ def create_or_update_env_var(config, key, value=None, value_from=None):
 
 def update_env_var(config, key, value=None, value_from=None):
     logger.warning(
-        "update_env_var is deprecated, use create_or_update_env_var instead"
-        "This will be deprecated in 0.9.4, and will be removed in 1.0.0",
+        'update_env_var is deprecated, use create_or_update_env_var instead'
+        'This will be deprecated in 0.9.4, and will be removed in 1.0.0',
     )
     create_or_update_env_var(config, key, value=value, value_from=value_from)
 

--- a/nuclio/config.py
+++ b/nuclio/config.py
@@ -195,7 +195,7 @@ def set_env(config, env):
             for key in ['V3IO_FRAMESD', 'V3IO_USERNAME',
                         'V3IO_ACCESS_KEY', 'V3IO_API']:
                 if key in environ:
-                    update_env_var(config, key, environ[key])
+                    create_or_update_env_var(config, key, environ[key])
             continue
 
         key, value = parse_env(line)
@@ -204,17 +204,17 @@ def set_env(config, env):
                 'cannot parse environment value from: {}'.format(line))
 
         # TODO: allow external source env with magic
-        update_env_var(config, key, value)
+        create_or_update_env_var(config, key, value)
 
 
 def set_env_dict(config, env={}):
     for k, v in env.items():
-        update_env_var(config, k, value=str(v))
+        create_or_update_env_var(config, k, value=str(v))
 
 
 def set_external_source_env_dict(config, external_source_env={}):
     for k, v in external_source_env.items():
-        update_env_var(config, k, value_from=v)
+        create_or_update_env_var(config, k, value_from=v)
 
 
 def create_or_update_env_var(config, key, value=None, value_from=None):
@@ -240,7 +240,7 @@ def create_or_update_env_var(config, key, value=None, value_from=None):
 
 
 def update_env_var(config, key, value=None, value_from=None):
-    logger.warning('This function is deprecated, please use create_or_update_env_var instead')
+    # This function is deprecated, use create_or_update_env_var instead
     create_or_update_env_var(config, key, value=value, value_from=value_from)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,10 +27,10 @@ def get_env_var_from_list_by_key(env, key):
 def test_update_env_var_missing_value():
     config_dict = {'spec': {'env': []}}
     with pytest.raises(Exception, match='either value or value_from required for env var: name'):
-        config.update_env_var(config_dict, 'name')
+        config.create_or_update_env_var(config_dict, 'name')
 
 
-def test_update_env_var_existing_key():
+def test_create_or_update_env_var_existing_key():
     config_dict = {'spec': {
             'env': [
                 {'name': 'key', 'value': 'value1'},
@@ -38,24 +38,24 @@ def test_update_env_var_existing_key():
             ]
         }
     }
-    config.update_env_var(config_dict, 'key', value='value2')
+    config.create_or_update_env_var(config_dict, 'key', value='value2')
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
         'env var was not updated'
 
     value_from = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
-    config.update_env_var(config_dict, 'key2', value_from=value_from)
+    config.create_or_update_env_var(config_dict, 'key2', value_from=value_from)
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key2')['valueFrom'] == value_from,\
         'env var was not updated'
 
 
-def test_update_env_var_new_key():
+def test_create_or_update_env_var_new_key():
     config_dict = {'spec': {'env': []}}
-    config.update_env_var(config_dict, 'key', value='value2')
+    config.create_or_update_env_var(config_dict, 'key', value='value2')
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key')['value'] == 'value2',\
         'env var was not added'
 
     value_from = {"secretKeyRef": {"name": "secret1", "key": "secret-key1"}}
-    config.update_env_var(config_dict, 'key2', value_from=value_from)
+    config.create_or_update_env_var(config_dict, 'key2', value_from=value_from)
     assert get_env_var_from_list_by_key(config_dict['spec']['env'], 'key2')['valueFrom'] == value_from,\
         'env var was not added'
 


### PR DESCRIPTION
fix for update_env_var:

- rename `update_env_var` to `create_or_update_env_var`
- Improve logic readability
- add setdefault for config.spec["env"] to avoid KeyError