### PR TITLE
Stream Trigger - support explicit ack mode

### DIFF
--- a/nuclio/triggers.py
+++ b/nuclio/triggers.py
@@ -171,6 +171,7 @@ class KafkaTrigger(NuclioTrigger):
         partitions=None,
         consumer_group="kafka",
         initial_offset="earliest",
+        explicit_ack_mode=None,
         extra_attributes=None,
     ):
         super(KafkaTrigger, self).__init__(
@@ -192,6 +193,8 @@ class KafkaTrigger(NuclioTrigger):
         partitions = partitions or []
         if partitions:
             self._struct["attributes"]["partitions"] = partitions
+        if explicit_ack_mode:
+            self._struct["explicitAckMode"] = explicit_ack_mode
         self._add_extra_attrs(extra_attributes)
 
     def sasl(self, user="", password=""):
@@ -224,6 +227,7 @@ class V3IOStreamTrigger(NuclioTrigger):
         consumerGroup: str = "default",
         sequenceNumCommitInterval: str = "1s",
         heartbeatInterval: str = "3s",
+        explicit_ack_mode: str = None,
         extra_attributes=None,
     ):
         if url and not container and not path:
@@ -260,6 +264,8 @@ class V3IOStreamTrigger(NuclioTrigger):
             struct["attributes"]["partitions"] = partitions
         if pollingIntervalMS:
             struct["attributes"]["pollingIntervalMs"] = pollingIntervalMS
+        if explicit_ack_mode:
+            struct["explicitAckMode"] = explicit_ack_mode
         access_key = access_key if access_key else environ.get("V3IO_ACCESS_KEY")
         if not access_key:
             raise ValueError(

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pytest
 
-from nuclio.triggers import HttpTrigger, V3IOStreamTrigger, Constants
+from nuclio.triggers import HttpTrigger, V3IOStreamTrigger, KafkaTrigger, Constants
 
 
 def test_access_key_must_be_set():
@@ -29,6 +29,48 @@ def test_create_v3io_stream_trigger():
 
     v3io_stream_trigger = V3IOStreamTrigger(access_key="abc")
     assert v3io_stream_trigger.get_url == Constants.default_webapi_address
+
+
+def test_create_v3io_stream_trigger_with_explicit_ack_mode():
+    for explicit_ack_mode in [
+        None,
+        "enable",
+        "explicitOnly",
+    ]:
+        if not explicit_ack_mode:
+            trigger = V3IOStreamTrigger(
+                url="some-url",
+                access_key="123",
+            )
+            assert not trigger._struct.get("explicitAckMode", None)
+        else:
+            trigger = V3IOStreamTrigger(
+                url="some-url",
+                access_key="123",
+                explicit_ack_mode=explicit_ack_mode,
+            )
+            assert trigger._struct.get("explicitAckMode") == explicit_ack_mode
+
+
+def test_create_kafka_trigger_with_explicit_ack_mode():
+    for explicit_ack_mode in [
+        None,
+        "enable",
+        "explicitOnly",
+    ]:
+        if not explicit_ack_mode:
+            trigger = KafkaTrigger(
+                brokers="some-brokers",
+                topics=["some-topic"],
+            )
+            assert not trigger._struct.get("explicitAckMode", None)
+        else:
+            trigger = KafkaTrigger(
+                brokers="some-brokers",
+                topics=["some-topic"],
+                explicit_ack_mode=explicit_ack_mode,
+            )
+            assert trigger._struct.get("explicitAckMode") == explicit_ack_mode
 
 
 def test_cast_http_trigger_port_to_int():


### PR DESCRIPTION
Support enabling explicit ack in Kafka and V3IO stream triggers.
The supported modes are:
- "disable"
- "enable"
- "explicitOnly"

When not given, the Nuclio backend defaults the mode to "disable".