### PR TITLE
[Logger] Fix multiple logs for multiple handlers

### DIFF
--- a/nuclio/request.py
+++ b/nuclio/request.py
@@ -67,32 +67,27 @@ class Context(object):
 
 class Logger(object):
 
-    def __init__(self, level):
-        self._logger = logging.getLogger('nuclio_sdk')
+    def __init__(self, level, name='nuclio_jupyter'):
+        self._logger = logging.getLogger(name)
         self._logger.setLevel(level)
-        self._handlers = {}
 
     def set_handler(self, handler_name, file, formatter):
 
         # check if there's a handler by this name
-        if handler_name in self._handlers:
-
-            # log that we're removing it
-            self.info_with('Replacing logger output')
-
-            self._logger.removeHandler(self._handlers[handler_name])
+        for handler in self._logger.handlers:
+            if handler.name == handler_name:
+                self._logger.removeHandler(handler)
+                break
 
         # create a stream handler from the file
         stream_handler = logging.StreamHandler(file)
+        stream_handler.name = handler_name
 
         # set the formatter
         stream_handler.setFormatter(formatter)
 
         # add the handler to the logger
         self._logger.addHandler(stream_handler)
-
-        # save as the named output
-        self._handlers[handler_name] = stream_handler
 
     def debug(self, message, *args):
         self._logger.debug(message, *args)


### PR DESCRIPTION
When multiple loggers are created with the same name, remove duplicate handlers so they won't logs the same messages multiple times.

Porting the fix from https://github.com/mlrun/mlrun/pull/3381 to nuclio-jupyter.