### PR TITLE
[Kafka] Make max_workers a configurable parameter for kafka trigger

### DIFF
--- a/nuclio/triggers.py
+++ b/nuclio/triggers.py
@@ -173,6 +173,7 @@ class KafkaTrigger(NuclioTrigger):
         partitions=None,
         consumer_group="kafka",
         initial_offset="earliest",
+        max_workers: int = 1,
         explicit_ack_mode=None,
         extra_attributes=None,
         session_timeout: str = "10s",
@@ -183,7 +184,7 @@ class KafkaTrigger(NuclioTrigger):
         super(KafkaTrigger, self).__init__(
             {
                 "kind": self.kind,
-                "maxWorkers": 1,
+                "maxWorkers": max_workers,
                 "attributes": {
                     "topics": topics,
                     "brokers": brokers,

--- a/nuclio/triggers.py
+++ b/nuclio/triggers.py
@@ -173,13 +173,13 @@ class KafkaTrigger(NuclioTrigger):
         partitions=None,
         consumer_group="kafka",
         initial_offset="earliest",
-        max_workers: int = 1,
         explicit_ack_mode=None,
         extra_attributes=None,
         session_timeout: str = "10s",
         heartbeat_interval: str = "3s",
         worker_allocation_mode: str = "pool",
         fetch_default: int = 1048576,
+        max_workers: int = 1,
     ):
         super(KafkaTrigger, self).__init__(
             {


### PR DESCRIPTION
We hardcoded maxWorkers parameter for kafka trigger, so it was always equal to 1. In this PR we make this parameter configurable.

https://jira.iguazeng.com/browse/NUC-120 