### PR TITLE
[Build] Add a `nuclio` suffix to the module name if function is being deployed from the file

### DIFF
--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -88,7 +88,7 @@ def build_file(filename='', name='', handler='', archive=False, project='',
     normalized_filebase = normalize_name(filebase) + '-nuclio'
     update_in(config, 'metadata.name', name)
     config = extend_config(config, spec, tag, filename)
-    set_handler(config, normalize_name(filebase), '' if kind else handler, ext)
+    set_handler(config, normalized_filebase, '' if kind else handler, ext)
 
     log = logger.info if verbose else logger.debug
     log('Code:\n{}'.format(code))

--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -84,6 +84,8 @@ def build_file(filename='', name='', handler='', archive=False, project='',
         code = add_kind_footer(kind, config, code)
 
     name = normalize_name(name or filebase)
+    # Avoid import issues if the filename is the same as an existing Python library by adding a Nuclio suffix
+    normalized_filebase = normalize_name(filebase) + '-nuclio'
     update_in(config, 'metadata.name', name)
     config = extend_config(config, spec, tag, filename)
     set_handler(config, normalize_name(filebase), '' if kind else handler, ext)


### PR DESCRIPTION
This PR addresses the issue where the name of a file in Nuclio conflicts with an existing Python library, causing the import to fail. To avoid such issues, we will add a `nuclio` suffix to the filename when a function is being created from a file. 

Jira - https://iguazio.atlassian.net/browse/ML-6737