### PR TITLE
[Requirements] Limit boto3 version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ nbconvert = ">=6.4.5"
 notebook = ">=6.4, <7.0.0"
 pyyaml = ">=3.13, <7"
 requests = ">=2.31.0"
-boto3 = "==1.33.13"
+boto3 = ">=1.28.0, <1.29.0"
 importlib-metadata = "<8.0.0"
 ipython = ">=7.27.0"
 


### PR DESCRIPTION
It conflicts with the requirements in MLRun https://github.com/mlrun/mlrun/blob/development/extras-requirements.txt#L16