### PR TITLE
[Archive] Fix S3Repo to return decoded string instead of bytes

### DIFF
--- a/nuclio/archive.py
+++ b/nuclio/archive.py
@@ -197,7 +197,8 @@ class S3Repo(ExternalRepo):
 
     def get(self):
         obj = self.s3.Object(self.bucket, self.key)
-        return obj.get()['Body'].read()
+        bytes = obj.get()['Body'].read()
+        return bytes.decode("utf-8")
 
     def put(self, data):
         self.s3.Object(self.bucket, self.key).put(Body=data)

--- a/nuclio/archive.py
+++ b/nuclio/archive.py
@@ -197,8 +197,7 @@ class S3Repo(ExternalRepo):
 
     def get(self):
         obj = self.s3.Object(self.bucket, self.key)
-        bytes = obj.get()['Body'].read()
-        return bytes.decode("utf-8")
+        return obj.get()['Body'].read()
 
     def put(self, data):
         self.s3.Object(self.bucket, self.key).put(Body=data)

--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -66,7 +66,7 @@ def build_file(filename='', name='', handler='', archive=False, project='',
 
     elif ext in ['.py', '.go', '.js', '.java', '.sh']:
         code = url2repo(filename).get()
-        config, _ = code2config(code, ext)
+        config, code = code2config(code, ext)
         is_source = True
 
     elif ext == '.yaml':
@@ -215,6 +215,8 @@ def add_kind_footer(kind, config, code, always=False):
 
 def code2config(code, ext='.py', kind=None):
     config = new_config()
+    if isinstance(code, bytes):
+        code = code.decode('utf-8')
     if ext == '.go':
         config['spec']['runtime'] = 'golang'
     elif ext == '.js':

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -87,10 +87,11 @@ def test_build_file_nb_ignored_tags():
     assert code.find("test3") == -1, "did not ignore 'my-ignore-tag'"
 
 
-def test_build_file_from_s3():
+@pytest.mark.parametrize("mocked_content", [b"print('hello from bytes')", "print('hello from str')"])
+def test_build_file_from_s3(mocked_content):
     # Prepare a fake S3 object response returning bytes
     fake_body = mock.MagicMock()
-    fake_body.read.return_value = b"print('hello world')"
+    fake_body.read.return_value = mocked_content
     fake_obj = mock.MagicMock()
     fake_obj.get.return_value = {'Body': fake_body}
 
@@ -102,7 +103,7 @@ def test_build_file_from_s3():
         _, _, code = build_file('s3://bucket/key.py', name='s3func')
 
         # Verify that the returned code is a string, meaning the bytes were decoded properly
-        assert isinstance(code, str)
+        assert isinstance(code, str), "Expected code to be a string, got {}".format(type(code))
 
 
 def test_build_url(url_filepath):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,7 +17,6 @@ import shutil
 from unittest import mock
 
 import pytest
-from nuclio.archive import S3Repo
 
 from nuclio.build import build_file
 from nuclio.config import ConfigSpec, meta_keys, get_in
@@ -104,6 +103,7 @@ def test_build_file_from_s3():
 
         # Verify that the returned code is a string, meaning the bytes were decoded properly
         assert isinstance(code, str)
+
 
 def test_build_url(url_filepath):
     name, config, code = build_file(url_filepath,


### PR DESCRIPTION
Previously, when `build_file` was called with an S3 path, the content fetched via `S3Repo.get()` was returned as bytes. This caused issues later in the `code2config` flow, where a string was expected and operations like `encode` failed.

This PR fixes the bug by updating `S3Repo.get()` to decode the S3 object content into a string.

Jira:
https://iguazio.atlassian.net/browse/ML-10411