### PR TITLE
Define handler as an async generator in `mlrun_footer`

### DIFF
--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -194,6 +194,7 @@ def build_notebook(nb_file, no_embed=False, tag="", name="", ignored_tags=""):
 mlrun_footer = '''
 from mlrun.runtimes import nuclio_init_hook
 import asyncio
+import inspect
 
 def init_context(context):
     nuclio_init_hook(context, globals(), '{}')
@@ -201,9 +202,16 @@ def init_context(context):
 
 async def handler(context, event):
     result = context.mlrun_handler(context, event)
-    if asyncio.iscoroutine(result):
-        return await result
-    return result
+    if inspect.isasyncgen(result):
+        async for chunk in result:
+            yield chunk
+    elif inspect.isgenerator(result):
+        for chunk in result:
+            yield chunk
+    elif asyncio.iscoroutine(result):
+        yield await result
+    else:
+        yield result
 '''
 
 

--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -195,7 +195,6 @@ mlrun_footer = '''
 from mlrun.runtimes import nuclio_init_hook
 import asyncio
 import inspect
-import nuclio_sdk
 
 def init_context(context):
     nuclio_init_hook(context, globals(), '{}')
@@ -206,7 +205,7 @@ async def handler(context, event):
     if asyncio.iscoroutine(result):
         return await result
     elif inspect.isgenerator(result) or inspect.isasyncgen(result):
-        return nuclio_sdk.Response(body=result)
+        return context.Response(body=result)
     else:
         return result
 '''

--- a/nuclio/build.py
+++ b/nuclio/build.py
@@ -195,6 +195,7 @@ mlrun_footer = '''
 from mlrun.runtimes import nuclio_init_hook
 import asyncio
 import inspect
+import nuclio_sdk
 
 def init_context(context):
     nuclio_init_hook(context, globals(), '{}')
@@ -202,16 +203,12 @@ def init_context(context):
 
 async def handler(context, event):
     result = context.mlrun_handler(context, event)
-    if inspect.isasyncgen(result):
-        async for chunk in result:
-            yield chunk
-    elif inspect.isgenerator(result):
-        for chunk in result:
-            yield chunk
-    elif asyncio.iscoroutine(result):
-        yield await result
+    if asyncio.iscoroutine(result):
+        return await result
+    elif inspect.isgenerator(result) or inspect.isasyncgen(result):
+        return nuclio_sdk.Response(body=result)
     else:
-        yield result
+        return result
 '''
 
 


### PR DESCRIPTION
[ML-11876](https://iguazio.atlassian.net/browse/ML-11876)

Required for https://github.com/mlrun/mlrun/pull/9248.

This is necessary because nuclio's Python wrapper performs static checks on the handler, meaning that it cannot simply act as a pass-through for whaterver `context.mlrun_handler(context, event)` returns.

[ML-11876]: https://iguazio.atlassian.net/browse/ML-11876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ